### PR TITLE
Use RPC secret

### DIFF
--- a/src/contexts/ContextProvider.tsx
+++ b/src/contexts/ContextProvider.tsx
@@ -17,7 +17,7 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const { autoConnect } = useAutoConnect();
     const { networkConfiguration } = useNetworkConfiguration();
     const network = networkConfiguration as WalletAdapterNetwork;
-    const endpoint = useMemo(() => clusterApiUrl(network), [network]);
+    const endpoint = useMemo(() => process.env.NEXT_PUBLIC_MAINNET_RPC, []);
 
     console.log(network);
 

--- a/src/hooks/useTransactionListener.tsx
+++ b/src/hooks/useTransactionListener.tsx
@@ -25,7 +25,7 @@ export default function useTransactionListener(reference: PublicKey) {
         }
         console.error('Unknown error', e)
       }
-    }, 500)
+    }, 5000)
     return () => {
       clearInterval(interval)
     }


### PR DESCRIPTION
As the default Solana RPC has limitations we have to create endpoint with token to reuse for listening for transaction details, more informations, also increase the delay between calls